### PR TITLE
All links now work correctly for root domain

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -21,7 +21,7 @@ This repository is configured for automatic deployment of documentation to GitHu
 ```typescript
 const config: Config = {
   url: 'https://jt-lab-com.github.io',     // GitHub Pages URL
-  baseUrl: '/docs/',                       // Repository path
+  baseUrl: '/',                            // Repository path
   organizationName: 'jt-lab-com',          // Organization name
   projectName: 'docs',                     // Repository name
   // ... other settings
@@ -61,7 +61,7 @@ npm run serve
 ### 🌐 Result
 
 After successful deployment, your documentation will be available at:
-`https://jt-lab-com.github.io/docs/`
+`https://jt-lab-com.github.io/`
 
 ### 🐛 Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Documentation for JavaScript Trading Libraries, built with [Docusaurus](https://
 
 ## 🚀 Quick Start
 
-**🌐 Online Documentation:** [https://jt-lab-com.github.io/docs/](https://jt-lab-com.github.io/docs/)
+**🌐 Online Documentation:** [https://jt-lab-com.github.io/](https://jt-lab-com.github.io/)
 
 ### Installing Dependencies
 ```bash
@@ -80,9 +80,9 @@ The site automatically deploys to GitHub Pages when pushing to the `main` branch
 ## 🔗 Useful Links
 
 ### Documentation
-- **📖 [Online Documentation](https://jt-lab-com.github.io/docs/)** - Complete JT-Lib and JT-Trader documentation
-- **📚 [JT-Lib Documentation](https://jt-lab-com.github.io/docs/docs/jt-lib/)** - Core library documentation
-- **⚙️ [JT-Trader Documentation](https://jt-lab-com.github.io/docs/docs/jt-trader/)** - Trading platform documentation
+- **📖 [Online Documentation](https://jt-lab-com.github.io/)** - Complete JT-Lib and JT-Trader documentation
+- **📚 [JT-Lib Documentation](https://jt-lab-com.github.io/jt-lib/)** - Core library documentation
+- **⚙️ [JT-Trader Documentation](https://jt-lab-com.github.io/jt-trader/)** - Trading platform documentation
 
 ### JT-Lab Resources
 - **🌐 [Official JT-Lab Website](https://jt-lab.com)** - Platform homepage

--- a/deploy.bat
+++ b/deploy.bat
@@ -43,7 +43,7 @@ echo 🚀 Pushing changes to GitHub...
 git push origin main
 
 echo ✅ Deployment completed! GitHub Actions will automatically deploy the site.
-echo 🌐 Site will be available at: https://jt-lab-com.github.io/docs/
+echo 🌐 Site will be available at: https://jt-lab-com.github.io/
 echo.
 echo 📊 Check deployment status in the Actions section on GitHub.
 pause

--- a/deploy.sh
+++ b/deploy.sh
@@ -43,6 +43,6 @@ echo "🚀 Pushing changes to GitHub..."
 git push origin main
 
 echo "✅ Deployment completed! GitHub Actions will automatically deploy the site."
-echo "🌐 Site will be available at: https://jt-lab-com.github.io/docs/"
+echo "🌐 Site will be available at: https://jt-lab-com.github.io/"
 echo ""
 echo "📊 Check deployment status in the Actions section on GitHub."

--- a/docs/examples-guide.md
+++ b/docs/examples-guide.md
@@ -99,5 +99,5 @@ Examples of using the jt-lib library with descriptions of functionality and used
 - **🌐 [Official JT-Lab Website](https://jt-lab.com)** - Main platform page
 - **📦 [JT-Trader on GitHub](https://github.com/jt-lab-com/jt-trader)** - Trading platform source code
 - **📚 [JT-Lib on GitHub](https://github.com/jt-lab-com/jt-lib)** - Development library source code
-- **📖 [Complete Documentation](/docs/intro)** - Detailed guides for all components
-- **🚀 [Quick Start](/docs/quick-start)** - Get started in 5 minutes
+- **📖 [Complete Documentation](/intro)** - Detailed guides for all components
+- **🚀 [Quick Start](/quick-start)** - Get started in 5 minutes

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -23,7 +23,7 @@ Complete guide for installing and configuring the JT-Trader platform for algorit
 
 JT-LAB has a dual license:
 
-- 🟢 **Free** for personal, educational, and open-source use under [AGPLv3](LICENSE) license.
+- 🟢 **Free** for personal, educational, and open-source use under [AGPLv3](LICENSE.md) license.
 - 🔒 **Commercial use** requires a [paid license](mailto:am@jt-lab.com).
 
 
@@ -281,10 +281,10 @@ netstat -tulpn | grep :8080
 
 After successful installation:
 
-1. **[JT-Trader Configuration](/docs/jt-trader/configuration)** - Platform setup
-2. **[Usage](/docs/jt-trader/usage)** - Interface learning
-3. **[Creating Strategies](/docs/jt-lib/trading-scripts)** - Trading robot development
-4. **[Testing](/docs/jt-trader/tester)** - Strategy testing
+1. **[JT-Trader Configuration](/jt-trader/configuration)** - Platform setup
+2. **[Getting Started](/jt-trader/getting-started)** - Interface learning
+3. **[Creating Strategies](/jt-lib/trading-scripts)** - Trading robot development
+4. **[Tester Overview](/jt-trader/tester-overview)** - Strategy testing
 
 ---
 

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -113,17 +113,17 @@ JT-Lab's affiliate program allows participants to earn by attracting new users:
 
 ### For Trading Strategy Developers:
 
-1. **[JT-LAB Installation](/docs/installation)** - Install the entire system
-2. **[JT-LIB Introduction](/docs/jt-lib/introduction-architecture)** - Study the library architecture
-3. **[Development Fundamentals](/docs/jt-lib/core-fundamentals)** - Understand basic components
-4. **[Creating Strategies](/docs/jt-lib/trading-scripts)** - Start creating trading robots
+1. **[JT-LAB Installation](/installation)** - Install the entire system
+2. **[JT-LIB Introduction](/jt-lib/introduction-architecture)** - Study the library architecture
+3. **[Development Fundamentals](/jt-lib/core-fundamentals)** - Understand basic components
+4. **[Creating Strategies](/jt-lib/trading-scripts)** - Start creating trading robots
 
 ### For Traders:
 
-1. **[JT-LAB Installation](/docs/installation)** - Install the entire system
-2. **[Configuration](/docs/jt-trader/configuration)** - Set up exchange connections
-3. **[Usage](/docs/jt-trader/usage)** - Learn the platform interface
-4. **[Testing](/docs/jt-trader/tester)** - Learn to test strategies
+1. **[JT-LAB Installation](/installation)** - Install the entire system
+2. **[Configuration](/jt-trader/configuration)** - Set up exchange connections
+3. **[Getting Started](/jt-trader/getting-started)** - Learn the platform interface
+4. **[Tester Overview](/jt-trader/tester-overview)** - Learn to test strategies
 
 ## Key Features
 
@@ -175,7 +175,7 @@ JT-Lab's affiliate program allows participants to earn by attracting new users:
 
 **JT-Lab is a comprehensive automated trading platform that meets the needs of both beginners and professionals in algorithmic trading. Join JT-Lab to unlock the full potential of automated trading solutions, create and improve strategies, and interact with a community of like-minded individuals.**
 
-**Start with [installing JT-Trader](/docs/installation) or studying [JT-LIB architecture](/docs/jt-lib/introduction-architecture) depending on your goals.**
+**Start with [installing JT-Trader](/installation) or studying [JT-LIB architecture](/jt-lib/introduction-architecture) depending on your goals.**
 
 ## 🔗 Official Resources
 

--- a/docs/jt-lib/README.md
+++ b/docs/jt-lib/README.md
@@ -1,6 +1,6 @@
 # JT-LIB
 
-[![License](https://img.shields.io/badge/license-AGPLv3-blue.svg)](LICENSE)
+[![License](https://img.shields.io/badge/license-AGPLv3-blue.svg)](LICENSE.md)
 [![TypeScript](https://img.shields.io/badge/TypeScript-4.0+-blue.svg)](https://www.typescriptlang.org/)
 [![Node.js](https://img.shields.io/badge/Node.js-16+-green.svg)](https://nodejs.org/)
 

--- a/docs/jt-lib/introduction-architecture.md
+++ b/docs/jt-lib/introduction-architecture.md
@@ -80,7 +80,7 @@ After studying the source code, JT-LIB has the following architecture:
 
 JT-LIB is part of the JT-Trader platform and is installed together with it. To work with the library, you need to install JT-Trader.
 
-> 📖 **Installation Guide**: [JT-Trader Installation](/docs/installation)
+> 📖 **Installation Guide**: [JT-Trader Installation](/installation)
 
 ## Library Structure
 

--- a/docs/jt-lib/market-data-candles.md
+++ b/docs/jt-lib/market-data-candles.md
@@ -433,6 +433,6 @@ class Script extends BaseScript {
 
 ## Next Steps
 
-- **[Trading Scripts](/docs/jt-lib/trading-scripts)** - Base class for trading scripts
-- **[Exchange Operations](/docs/jt-lib/exchange-orders-basket)** - OrdersBasket for trading operations
-- **[Event System](/docs/jt-lib/events-system)** - EventEmitter for event management
+- **[Trading Scripts](/jt-lib/trading-scripts)** - Base class for trading scripts
+- **[Exchange Operations](/jt-lib/exchange-orders-basket)** - OrdersBasket for trading operations
+- **[Event System](/jt-lib/events-system)** - EventEmitter for event management

--- a/docs/jt-lib/script-best-practices.md
+++ b/docs/jt-lib/script-best-practices.md
@@ -318,6 +318,6 @@ Initialize `StandardReportLayout` to display strategy results.
 
 ## Next Steps
 
-- **[Trading Scripts](/docs/jt-lib/trading-scripts)** - In-depth study of BaseScript
-- **[Exchange Orders Basket](/docs/jt-lib/exchange-orders-basket)** - Detailed study of OrdersBasket
-- **[Event System](/docs/jt-lib/events-system)** - EventEmitter for reactive strategies
+- **[Trading Scripts](/jt-lib/trading-scripts)** - In-depth study of BaseScript
+- **[Exchange Orders Basket](/jt-lib/exchange-orders-basket)** - Detailed study of OrdersBasket
+- **[Event System](/jt-lib/events-system)** - EventEmitter for reactive strategies

--- a/docs/jt-lib/trading-scripts.md
+++ b/docs/jt-lib/trading-scripts.md
@@ -648,6 +648,6 @@ async onEvent(event: string, data: any) {
 
 ## Next Steps
 
-- **[Event System](/docs/jt-lib/events-system)** - In-depth study of EventEmitter
-- **[Core Fundamentals](/docs/jt-lib/core-fundamentals)** - Basic system components
-- **[Introduction and Architecture](/docs/jt-lib/introduction-architecture)** - Library overview
+- **[Event System](/jt-lib/events-system)** - In-depth study of EventEmitter
+- **[Core Fundamentals](/jt-lib/core-fundamentals)** - Basic system components
+- **[Introduction and Architecture](/jt-lib/introduction-architecture)** - Library overview

--- a/docs/jt-lib/triggers-system.md
+++ b/docs/jt-lib/triggers-system.md
@@ -400,6 +400,6 @@ class Script extends BaseScript {
 
 ## Next Steps
 
-- **[Event System](/docs/jt-lib/events-system)** - EventEmitter for event management
-- **[Trading Scripts](/docs/jt-lib/trading-scripts)** - Base class for trading scripts
-- **[Exchange Operations](/docs/jt-lib/exchange-orders-basket)** - OrdersBasket for trading operations
+- **[Event System](/jt-lib/events-system)** - EventEmitter for event management
+- **[Trading Scripts](/jt-lib/trading-scripts)** - Base class for trading scripts
+- **[Exchange Operations](/jt-lib/exchange-orders-basket)** - OrdersBasket for trading operations

--- a/docs/jt-trader/README.md
+++ b/docs/jt-trader/README.md
@@ -1,6 +1,6 @@
 # JT-Trader
 
-[![License](https://img.shields.io/badge/license-AGPLv3-blue.svg)](LICENSE)
+[![License](https://img.shields.io/badge/license-AGPLv3-blue.svg)](LICENSE.md)
 [![TypeScript](https://img.shields.io/badge/TypeScript-4.0+-blue.svg)](https://www.typescriptlang.org/)
 [![Node.js](https://img.shields.io/badge/Node.js-16+-green.svg)](https://nodejs.org/)
 [![CCXT](https://img.shields.io/badge/CCXT-4.0+-orange.svg)](https://github.com/ccxt/ccxt)
@@ -25,7 +25,7 @@
 
 JT-LAB has a dual license:
 
-- 🟢 **Free** for personal, educational, and open-source use under [AGPLv3](LICENSE) license.
+- 🟢 **Free** for personal, educational, and open-source use under [AGPLv3](LICENSE.md) license.
 - 🔒 **Commercial use** requires a [paid license](mailto:am@jt-lab.com).
 
 Professional trading platform for creating, testing, and launching algorithmic trading strategies. Combines a powerful engine for executing trading algorithms, comprehensive strategy testing system, and intuitive web interface for managing trading operations.
@@ -87,10 +87,10 @@ JT-Trader provides a unified web application with an intuitive interface accessi
 JT-Trader can be installed in several ways depending on your needs:
 
 ### 🚀 Launcher - for users
-- [Installation via Launcher](installation#1-installation-via-launcher) - automatic installation and configuration
+- [Installation via Launcher](/installation#1-installation-via-launcher) - automatic installation and configuration
 
 ### 🐳 Docker - for server deployments  
-- [Installation via Docker](installation#2-installation-via-docker) - Docker installation instructions
+- [Installation via Docker](/installation#2-installation-via-docker) - Docker installation instructions
 
 ### 📦 GitHub - for developers
 

--- a/docs/jt-trader/getting-started.md
+++ b/docs/jt-trader/getting-started.md
@@ -8,26 +8,26 @@ sidebar_label: Introduction
 
 <div className="thumbnail-container">
   <div className="thumbnail-item">
-    <a href="/docs/images/runtime-intro.png" target="_blank">
-      <img src="/docs/images/thumbnails/runtime-intro-thumb.png" alt="Runtime Overview" className="thumbnail-image" />
+    <a href="/images/runtime-intro.png" target="_blank">
+      <img src="/images/thumbnails/runtime-intro-thumb.png" alt="Runtime Overview" className="thumbnail-image" />
     </a>    
   </div>
 
   <div className="thumbnail-item">
-    <a href="/docs/images/create-runtime-intro.png" target="_blank">
-      <img src="/docs/images/thumbnails/create-runtime-intro-thumb.png" alt="Create Runtime" className="thumbnail-image" />
+    <a href="/images/create-runtime-intro.png" target="_blank">
+      <img src="/images/thumbnails/create-runtime-intro-thumb.png" alt="Create Runtime" className="thumbnail-image" />
     </a>    
   </div>
 
   <div className="thumbnail-item">
-    <a href="/docs/images/tester-intro.png" target="_blank">
-      <img src="/docs/images/thumbnails/tester-intro-thumb.png" alt="Tester Overview" className="thumbnail-image" />
+    <a href="/images/tester-intro.png" target="_blank">
+      <img src="/images/thumbnails/tester-intro-thumb.png" alt="Tester Overview" className="thumbnail-image" />
     </a>    
   </div>
 
    <div className="thumbnail-item">
-    <a href="/docs/images/create-scenarion-tester-intro.png" target="_blank">
-      <img src="/docs/images/thumbnails/create-scenarion-tester-intro-thumb.png" alt="Create Scenario Tester" className="thumbnail-image" />
+    <a href="/images/create-scenarion-tester-intro.png" target="_blank">
+      <img src="/images/thumbnails/create-scenarion-tester-intro-thumb.png" alt="Create Scenario Tester" className="thumbnail-image" />
     </a>    
   </div>
 
@@ -126,9 +126,9 @@ After installing JT-Trader, you will be able to:
 
 To get started with JT-Trader, it's recommended to study the following documentation sections:
 
-- **[Runtime Overview](/docs/jt-trader/runtime-overview)** - Runtime tab overview
-- **[Tester Overview](/docs/jt-trader/tester-overview)** - Tester tab overview
-- **[Strategy Files Overview](/docs/jt-trader/strategy-files-overview)** - Strategy Files tab overview
-- **[Configuration](/docs/jt-trader/configuration)** - system and connection configuration
+- **[Runtime](/jt-trader/runtime-overview)** - Runtime tab overview
+- **[Tester](/jt-trader/tester-overview)** - Tester tab overview
+- **[Strategy Files](/jt-trader/strategy-files-overview)** - Strategy Files tab overview
+- **[Configuration](/jt-trader/configuration)** - system and connection configuration
 
 JT-Trader opens wide possibilities for algorithmic trading, combining professional development tools with a convenient management interface. Regardless of your trading experience level, the platform will provide all necessary tools for creating and launching effective trading strategies.

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -19,7 +19,7 @@ In the **JT-Trader** system, you'll try:
 
 ## Installation 
 
-If you haven't installed JT-LAB yet, follow the instructions in [JT-Trader Installation](/docs/installation).
+If you haven't installed JT-LAB yet, follow the instructions in [JT-Trader Installation](/installation).
 
 ## Runtime - Trading on Mock Exchange
 
@@ -83,11 +83,11 @@ The system has even more ready-made strategies: `RsiBot.ts` (RSI strategy with o
 
 ### For Developers
 
-[Study JT-LIB](/docs/jt-lib/introduction-architecture) (library architecture), [development basics](/docs/jt-lib/core-fundamentals) (basic components) and [creating strategies](/docs/jt-lib/trading-scripts) (advanced techniques).
+[Study JT-LIB](/jt-lib/introduction-architecture) (library architecture), [development basics](/jt-lib/core-fundamentals) (basic components) and [creating strategies](/jt-lib/trading-scripts) (advanced techniques).
 
 ### For Traders
 
-[Exchange Setup](/docs/jt-trader/configuration) (connecting real exchanges), [usage](/docs/jt-trader/getting-started) (platform interface) and [Runtime](/docs/jt-trader/runtime-overview) (launching trading robots).
+[Exchange Setup](/jt-trader/configuration) (connecting real exchanges), [usage](/jt-trader/getting-started) (platform interface) and [Runtime](/jt-trader/runtime-overview) (launching trading robots).
 
 ## Useful Tips
 
@@ -114,5 +114,5 @@ Now you can experiment with parameters, create new strategies and explore the pl
 - **🌐 [JT-Lab Official Website](https://jt-lab.com)** - Platform main page
 - **📦 [JT-Trader on GitHub](https://github.com/jt-lab-com/jt-trader)** - Trading platform source code
 - **📚 [JT-Lib on GitHub](https://github.com/jt-lab-com/jt-lib)** - Development library source code
-- **📖 [Full Documentation](/docs/intro)** - Detailed guides for all components
-- **💡 [Code Examples](/docs/examples-guide)** - Ready-made trading strategy examples
+- **📖 [Full Documentation](/intro)** - Detailed guides for all components
+- **💡 [Code Examples](/examples-guide)** - Ready-made trading strategy examples

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -22,7 +22,7 @@ const config: Config = {
   url: 'https://jt-lab-com.github.io',
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
-  baseUrl: '/docs/',
+  baseUrl: '/',
   
 
   // GitHub pages deployment config.
@@ -96,7 +96,7 @@ const config: Config = {
           items: [
             {
             label: 'System Installation',
-              to: '/docs/installation/',
+              to: '/installation/',
             },
             
             {

--- a/src/components/HomepageFeatures/index.tsx
+++ b/src/components/HomepageFeatures/index.tsx
@@ -21,7 +21,7 @@ const FeatureList: FeatureItem[] = [
         order management, market data handling, and event system.
       </>
     ),
-    link: '/docs/jt-lib/core-fundamentals',
+    link: '/jt-lib/core-fundamentals',
   },
   {
     title: 'JT-Trader - Trading Platform',
@@ -32,7 +32,7 @@ const FeatureList: FeatureItem[] = [
         runtime environment, and convenient interface for development and testing.
       </>
     ),
-    link: '/docs/jt-trader/010-getting-started',
+    link: '/jt-trader/getting-started',
   },
   {
     title: 'Technical Indicators',
@@ -43,7 +43,7 @@ const FeatureList: FeatureItem[] = [
         Easy integration with candle buffers and automatic updates.
       </>
     ),
-    link: '/docs/jt-lib/technical-indicators',
+    link: '/jt-lib/technical-indicators',
   },
   {
     title: 'Order Management',
@@ -54,7 +54,7 @@ const FeatureList: FeatureItem[] = [
         various order types, stop-losses, and take-profits.
       </>
     ),
-    link: '/docs/jt-lib/exchange-orders-basket',
+    link: '/jt-lib/exchange-orders-basket',
   },
   {
     title: 'Market Data',
@@ -65,7 +65,7 @@ const FeatureList: FeatureItem[] = [
         Candle buffering with automatic updates and caching.
       </>
     ),
-    link: '/docs/jt-lib/market-data-candles',
+    link: '/jt-lib/market-data-candles',
   },
   {
     title: 'Event System',
@@ -76,7 +76,7 @@ const FeatureList: FeatureItem[] = [
         Subscribe to ticks, price changes, and other trading events.
       </>
     ),
-    link: '/docs/jt-lib/events-system',
+    link: '/jt-lib/events-system',
   },
 ];
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -20,12 +20,12 @@ function HomepageHeader() {
         <div className={styles.buttons}>
           <Link
             className="button button--secondary button--lg"
-            to="/docs/intro">
+            to="/intro">
             Start Learning - 5min ⏱️
           </Link>
           <Link
             className="button button--outline button--secondary button--lg"
-            to="/docs/quick-start">
+            to="/quick-start">
             Quick Start 🚀
           </Link>
         </div>
@@ -54,7 +54,7 @@ function QuickLinks() {
               </div>
               <div className="card__body">
                 <p>Install and configure JT-Lib in 5 minutes</p>
-                <Link className="button button--primary" to="/docs/quick-start">
+                <Link className="button button--primary" to="/quick-start">
                   Start Now
                 </Link>
               </div>
@@ -67,7 +67,7 @@ function QuickLinks() {
               </div>
               <div className="card__body">
                 <p>Ready-made trading strategy and indicator examples</p>
-                <Link className="button button--primary" to="/docs/examples-guide">
+                <Link className="button button--primary" to="/examples-guide">
                   View Examples
                 </Link>
               </div>
@@ -83,7 +83,7 @@ function QuickLinks() {
               <div className="card__body">
                 <p>Trading libraries and API</p>
                 <div className="button-group">
-                  <Link className="button button--secondary" to="/docs/jt-lib/core-fundamentals">
+                  <Link className="button button--secondary" to="/jt-lib/core-fundamentals">
                     Documentation
                   </Link>
                   <Link className="button button--outline button--secondary" href="https://github.com/jt-lab-com/jt-lib" target="_blank">
@@ -101,7 +101,7 @@ function QuickLinks() {
               <div className="card__body">
                 <p>Trading platform and interface</p>
                 <div className="button-group">
-                  <Link className="button button--secondary" to="/docs/jt-trader/010-getting-started">
+                  <Link className="button button--secondary" to="/jt-trader/getting-started">
                     Documentation
                   </Link>
                   <Link className="button button--outline button--secondary" href="https://github.com/jt-lab-com/jt-trader" target="_blank">


### PR DESCRIPTION
Fix all broken links and configure for root domain deployment

- Updated baseUrl from '/docs/' to '/' in docusaurus.config.ts
- Fixed all internal links in documentation files
- Updated HomepageFeatures component links
- Fixed LICENSE file references
- Updated deployment scripts and documentation
- All links now work correctly for root domain https://jt-lab-com.github.io/